### PR TITLE
Fix pygeoapi limits config

### DIFF
--- a/local.config.yml
+++ b/local.config.yml
@@ -10,7 +10,9 @@ server:
   languages:
     - en-US
   pretty_print: true
-  limit: 10
+  limits: 
+    default_items: 100
+    max_items: 10000
   map:
     url: https://tile.openstreetmap.org/{z}/{x}/{y}.png
     attribution: '&copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'

--- a/local.config.yml
+++ b/local.config.yml
@@ -10,7 +10,7 @@ server:
   languages:
     - en-US
   pretty_print: true
-  limits: 
+  limits:
     default_items: 100
     max_items: 10000
   map:


### PR DESCRIPTION
Fix pygeoapi limits to allow the OAFeature provider to return more than 10 items.