### PR TITLE
Return all timeseries results from all RISE pages if no `datetime` is specified

### DIFF
--- a/makefile
+++ b/makefile
@@ -15,4 +15,4 @@ devNoOTEL:
 	OTEL_SDK_DISABLED=true PYGEOAPI_CONFIG=local.config.yml PYGEOAPI_OPENAPI=local.openapi.yml uv run pygeoapi serve --starlette
 
 test:
-	uv run pytest -n auto -x --maxfail=1 -vv
+	uv run pytest -n auto -x --maxfail=1 -vv --durations=5

--- a/rise/lib/add_results.py
+++ b/rise/lib/add_results.py
@@ -61,6 +61,7 @@ class LocationResultBuilder:
     def _get_all_timeseries_data(self, time_filter: Optional[str] = None):
         # Make a dictionary from an existing response
         catalogItemUrls = flatten_values(self.locationToCatalogItemUrls)
+
         resultUrls = {
             url: getResultUrlFromCatalogUrl(url, time_filter) for url in catalogItemUrls
         }
@@ -101,7 +102,7 @@ class LocationResultBuilder:
                 catalogUrlAsResultUrl = getResultUrlFromCatalogUrl(
                     catalogItemUrl, time_filter
                 )
-                timseriesResults = self.timeseriesResults[catalogUrlAsResultUrl]
+                timseriesResults = self.timeseriesResults.get(catalogUrlAsResultUrl)
                 # if there were no results for this catalog item, continue and don't even bother serializing
                 if not timseriesResults:
                     continue

--- a/rise/lib/add_results.py
+++ b/rise/lib/add_results.py
@@ -102,6 +102,10 @@ class LocationResultBuilder:
                     catalogItemUrl, time_filter
                 )
                 timseriesResults = self.timeseriesResults[catalogUrlAsResultUrl]
+                # if there were no results for this catalog item, continue and don't even bother serializing
+                if not timseriesResults:
+                    continue
+
                 if timseriesResults.get("detail") == "Internal Server Error":
                     await_(
                         self.cache.clear(catalogUrlAsResultUrl)

--- a/rise/lib/add_results.py
+++ b/rise/lib/add_results.py
@@ -61,18 +61,18 @@ class LocationResultBuilder:
     def _get_all_timeseries_data(self, time_filter: Optional[str] = None):
         # Make a dictionary from an existing response
         catalogItemUrls = flatten_values(self.locationToCatalogItemUrls)
-        resultUrls = [
-            getResultUrlFromCatalogUrl(url, time_filter) for url in catalogItemUrls
-        ]
+        resultUrls = {
+            url: getResultUrlFromCatalogUrl(url, time_filter) for url in catalogItemUrls
+        }
 
         if len(resultUrls) != len(set(resultUrls)):
             raise RuntimeError(
                 "Got duplicate result urls when loading timeseries data:",
-                set([x for x in resultUrls if resultUrls.count(x) > 1]),
+                set([x for x in resultUrls if list(resultUrls.keys()).count(x) > 1]),
             )
 
         LOGGER.debug(f"Fetching {resultUrls}; {len(resultUrls)} in total")
-        return await_(self.cache.get_or_fetch_group(resultUrls))
+        return await_(self.cache.get_or_fetch_all_results(resultUrls))
 
     def _get_timeseries_for_catalogitem(self, catalogItem):
         if catalogItem not in self.timeseriesResults:

--- a/rise/lib/cache.py
+++ b/rise/lib/cache.py
@@ -177,11 +177,17 @@ class RISECache:
             base_url = base_url.removesuffix("&")
         return await_(self.get_or_fetch_all_pages(base_url))
 
-
-    async def get_or_fetch_all_results(self, catalogItemToResultUrl: dict[str, str]) -> dict[str, JsonPayload]:
-        """Given a dictionary mapping catalog items to URLs, fetch all pages for each URL in parallel 
+    async def get_or_fetch_all_results(
+        self, catalogItemToResultUrl: dict[str, str]
+    ) -> dict[str, JsonPayload]:
+        """Given a dictionary mapping catalog items to URLs, fetch all pages for each URL in parallel
         and return a dictionary mapping catalog items to their corresponding merged pages."""
-        tasks = {resultUrl: asyncio.create_task(self.get_or_fetch_all_pages(resultUrl, force_fetch=True)) for _, resultUrl in catalogItemToResultUrl.items()}
+        tasks = {
+            resultUrl: asyncio.create_task(
+                self.get_or_fetch_all_pages(resultUrl, force_fetch=True)
+            )
+            for _, resultUrl in catalogItemToResultUrl.items()
+        }
 
         results = await asyncio.gather(*tasks.values())
 

--- a/rise/lib/cache.py
+++ b/rise/lib/cache.py
@@ -84,8 +84,10 @@ class RISECache:
         MAX_ITEMS_PER_PAGE: int 
 
         if "data.usbr.gov/rise/api/result" in base_url:
-            MAX_VALUES_IN_RISE_RESULT_PAGE = 10000 
-            MAX_ITEMS_PER_PAGE = MAX_VALUES_IN_RISE_RESULT_PAGE 
+            # there is a special case in RISE where the max number of items per result page is 10000
+            # this appears to be different from the other endpoints
+            MAX_ITEMS_PER_RESULT_PAGE = 10000 
+            MAX_ITEMS_PER_PAGE = MAX_ITEMS_PER_RESULT_PAGE
         else:
             MAX_ITEMS_PER_PAGE = 100
 

--- a/rise/lib/cache.py
+++ b/rise/lib/cache.py
@@ -80,13 +80,12 @@ class RISECache:
     async def get_or_fetch_all_pages(
         self, base_url: str, force_fetch=False
     ) -> dict[Url, JsonPayload]:
-
-        MAX_ITEMS_PER_PAGE: int 
+        MAX_ITEMS_PER_PAGE: int
 
         if "data.usbr.gov/rise/api/result" in base_url:
             # there is a special case in RISE where the max number of items per result page is 10000
             # this appears to be different from the other endpoints
-            MAX_ITEMS_PER_RESULT_PAGE = 10000 
+            MAX_ITEMS_PER_RESULT_PAGE = 10000
             MAX_ITEMS_PER_PAGE = MAX_ITEMS_PER_RESULT_PAGE
         else:
             MAX_ITEMS_PER_PAGE = 100

--- a/rise/lib/cache.py
+++ b/rise/lib/cache.py
@@ -80,8 +80,14 @@ class RISECache:
     async def get_or_fetch_all_pages(
         self, base_url: str, force_fetch=False
     ) -> dict[Url, JsonPayload]:
-        # max number of items you can query in RISE
-        MAX_ITEMS_PER_PAGE = 100
+
+        MAX_ITEMS_PER_PAGE: int 
+
+        if "data.usbr.gov/rise/api/result" in base_url:
+            MAX_VALUES_IN_RISE_RESULT_PAGE = 10000 
+            MAX_ITEMS_PER_PAGE = MAX_VALUES_IN_RISE_RESULT_PAGE 
+        else:
+            MAX_ITEMS_PER_PAGE = 100
 
         # Get the first response that contains the list of pages
         response = await self.get_or_fetch(base_url)

--- a/rise/lib/cache_test.py
+++ b/rise/lib/cache_test.py
@@ -7,10 +7,7 @@ import time
 
 import pytest
 from rise.lib.cache import RISECache
-from rise.lib.helpers import await_, flatten_values
-from rise.lib.location import LocationResponseWithIncluded
-from rise.lib.types import catalogItem
-from rise.lib.types.includes import LocationIncluded
+from rise.lib.helpers import await_
 
 
 @pytest.mark.asyncio
@@ -106,13 +103,15 @@ def test_safe_async():
     # Close the event loop after the test
     loop.close()
 
+
 @pytest.mark.asyncio
 async def test_fetch_all_results():
-    result_base_url = 'https://data.usbr.gov/rise/api/result?itemId=1'
+    result_base_url = "https://data.usbr.gov/rise/api/result?itemId=1"
     cache = RISECache()
-    results = await cache.get_or_fetch_all_results({
-        '1': result_base_url,
-    })
+    results = await cache.get_or_fetch_all_results(
+        {
+            "1": result_base_url,
+        }
+    )
     assert len(results) == 1
-    assert len(results[result_base_url]['data']) > 1000
-    
+    assert len(results[result_base_url]["data"]) > 1000

--- a/rise/lib/cache_test.py
+++ b/rise/lib/cache_test.py
@@ -7,7 +7,10 @@ import time
 
 import pytest
 from rise.lib.cache import RISECache
-from rise.lib.helpers import await_
+from rise.lib.helpers import await_, flatten_values
+from rise.lib.location import LocationResponseWithIncluded
+from rise.lib.types import catalogItem
+from rise.lib.types.includes import LocationIncluded
 
 
 @pytest.mark.asyncio
@@ -102,3 +105,14 @@ def test_safe_async():
 
     # Close the event loop after the test
     loop.close()
+
+@pytest.mark.asyncio
+async def test_fetch_all_results():
+    result_base_url = 'https://data.usbr.gov/rise/api/result?itemId=1'
+    cache = RISECache()
+    results = await cache.get_or_fetch_all_results({
+        '1': result_base_url,
+    })
+    assert len(results) == 1
+    assert len(results[result_base_url]['data']) > 1000
+    

--- a/rise/lib/geojson/types.py
+++ b/rise/lib/geojson/types.py
@@ -1,0 +1,20 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
+from typing import Literal, NotRequired, TypedDict
+
+
+class GeojsonFeature(TypedDict):
+    type: Literal["Feature"]
+    geometry: dict
+    properties: dict
+    id: int
+
+
+class GeojsonFeatureCollectionDict(TypedDict):
+    """A dict reprsentation of a GeoJSON FeatureCollection that is returned from OAF items/ queries"""
+
+    type: Literal["FeatureCollection"]
+    features: list[GeojsonFeature]
+    # numberMatched is not required because it is only returned when resulttype=hits
+    numberMatched: NotRequired[int]

--- a/rise/rise.py
+++ b/rise/rise.py
@@ -8,6 +8,7 @@ from pygeoapi.provider.base import BaseProvider
 from pygeoapi.util import crs_transform
 from rise.env import TRACER
 from rise.lib.cache import RISECache
+from rise.lib.geojson.types import GeojsonFeatureCollectionDict
 from rise.lib.location import LocationResponseWithIncluded
 from rise.lib.types.location import LocationDataAttributes
 from rise.lib.types.sorting import SortDict
@@ -50,7 +51,7 @@ class RiseProvider(BaseProvider):
         offset: Optional[int] = 0,
         skip_geometry: Optional[bool] = False,
         **kwargs,
-    ):
+    ) -> GeojsonFeatureCollectionDict:
         # we don't filter by parameters here since OAF filters features by
         # the attributes of the feature, not the parameters of the associated timeseries data
         raw_resp = self.cache.get_or_fetch_all_param_filtered_pages()

--- a/rise/rise_edr_test.py
+++ b/rise/rise_edr_test.py
@@ -32,13 +32,14 @@ def test_location_locationId(edr_config: dict):
 
     p = RiseEDRProvider()
     out = p.locations(location_id="1", format_="covjson")
+    assert "coverages" in out
     assert len(out["coverages"]) == catalogItems, (
         "There must be the same number of catalogItems as there are coverages"
     )
 
-    geojson_out: dict = p.locations(location_id=1, format_="geojson")  # type: ignore Have to ignore this since we know it is geojson
-    assert geojson_out["type"] == "Feature"
-    assert geojson_out["id"] == 1
+    geojson_out = p.locations(location_id="1", format_="geojson")
+    assert "features" in geojson_out
+    assert geojson_out["features"][0]["id"] == 1
 
 
 def test_invalid_location_id(edr_config: dict):
@@ -94,6 +95,7 @@ def test_location_select_properties(edr_config: dict):
     lakeReservoirStorage = "3"
     texasID291 = "291"
     out = p.locations(location_id=texasID291, select_properties=[lakeReservoirStorage])
+    assert "coverages" in out
     assert len(out["coverages"]) == 2, (
         "We expect to have both Lake/Reservoir Storage and Elevation unless more have been retroactively added"
     )
@@ -111,8 +113,8 @@ def test_location_select_properties_with_id_filter(edr_config: dict):
     out_prop_2_with_location_id_filter = p.locations(
         location_id="1", select_properties=["2"], format_="geojson"
     )
-    assert out_prop_2_with_location_id_filter["type"] == "Feature"
-    assert out_prop_2_with_location_id_filter["id"] == 1  # type: ignore
+    assert "features" in out_prop_2_with_location_id_filter
+    assert out_prop_2_with_location_id_filter["features"][0]["id"] == 1
 
 
 def test_location_datetime(edr_config: dict):
@@ -122,7 +124,7 @@ def test_location_datetime(edr_config: dict):
 
     start = datetime.datetime.fromisoformat("2017-01-01T00:00:00+00:00")
     end = datetime.datetime.fromisoformat("2018-01-01T00:00:00+00:00")
-
+    assert "coverages" in out
     for param in out["coverages"]:
         for time_val in param["domain"]["axes"]["t"]["values"]:
             assert start <= datetime.datetime.fromisoformat(time_val) <= end


### PR DESCRIPTION
Return all timeseries results from all pages to fully populate the locations with all their data