### PR TITLE
exclude null values and fix bbox null value

### DIFF
--- a/rise/lib/location.py
+++ b/rise/lib/location.py
@@ -342,7 +342,7 @@ class LocationResponse(BaseModel):
         validated_geojson = FeatureCollection(
             type="FeatureCollection", features=geojson_features
         )
-        return validated_geojson.model_dump(by_alias=True)
+        return validated_geojson.model_dump(by_alias=True, exclude_none=True)
 
 
 class LocationResponseWithIncluded(LocationResponse):


### PR DESCRIPTION
exclude null values when dumping the geojson.

This removes all empty values, I presume this is ok?